### PR TITLE
Apply parchment styling and fullscreen GUI

### DIFF
--- a/artiFACTv5.py
+++ b/artiFACTv5.py
@@ -11,20 +11,22 @@ from tensorflow.keras.preprocessing import image
 from keras.preprocessing.image import ImageDataGenerator
 from PIL import Image
 
-# Retro color palette - Vintage Computer Green Theme
-RETRO_COLORS = {
-    'bg_primary': '#0A0A0A',      # Deep black (like old CRT screens)
-    'bg_secondary': '#1A2F1A',    # Dark green-gray
-    'accent_green': '#00FF00',    # Bright green (classic terminal green)
-    'accent_cyan': '#00FFFF',     # Cyan for highlights
-    'text_light': '#C0C0C0',      # Light gray (like old monitors)
-    'text_dark': '#000000',       # Pure black
-    'button_bg': '#2F4F2F',       # Dark green
-    'button_hover': '#4F6F4F',    # Lighter green on hover
-    'success_green': '#00FF00',   # Bright green for success
-    'error_red': '#FF0000',       # Bright red for errors
-    'selection_green': '#00FF00',  # Bright green for selections
-    'border_green': '#00FF00'     # Green borders
+# Parchment-toned academic explorer color palette
+PARCHMENT_COLORS = {
+    'bg_primary': '#F5F1E8',      # Cream parchment background
+    'bg_secondary': '#E8E0D0',    # Lighter cream for sections
+    'accent_gold': '#D4AF37',     # Faint gold for highlights
+    'accent_rust': '#B7410E',     # Rust for important elements
+    'text_charcoal': '#2F2F2F',   # Charcoal for text
+    'text_olive': '#556B2F',      # Olive green for labels
+    'button_bg': '#8B7355',       # Warm brown for buttons
+    'button_hover': '#A0522D',    # Rust on hover
+    'success_green': '#556B2F',   # Olive green for success
+    'error_red': '#8B0000',       # Dark red for errors
+    'selection_gold': '#D4AF37',  # Gold for selections
+    'border_charcoal': '#2F2F2F', # Charcoal borders
+    'text_light': '#4A4A4A',      # Light charcoal for secondary text
+    'accent_olive': '#6B8E23'     # Brighter olive for accents
 }
 
 # Paths
@@ -86,156 +88,161 @@ def predict_with_description(input_data, top_k=1):
     return results
 
 
-class RetroButton(tk.Button):
-    """Custom retro-styled button"""
+class ParchmentButton(tk.Button):
+    """Custom parchment-styled button with academic explorer theme"""
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
         self.configure(
-            bg=RETRO_COLORS['button_bg'],
-            fg=RETRO_COLORS['accent_green'],
-            font=('Courier', 10, 'bold'),
+            bg=PARCHMENT_COLORS['button_bg'],
+            fg=PARCHMENT_COLORS['bg_primary'],
+            font=('Georgia', 10, 'bold'),
             relief='raised',
-            bd=3,
+            bd=2,
             padx=15,
             pady=8,
-            activebackground=RETRO_COLORS['button_hover'],
-            activeforeground=RETRO_COLORS['accent_green'],
-            highlightbackground=RETRO_COLORS['border_green'],
-            highlightthickness=2
+            activebackground=PARCHMENT_COLORS['button_hover'],
+            activeforeground=PARCHMENT_COLORS['bg_primary'],
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
+            highlightthickness=1
         )
         self.bind('<Enter>', self.on_enter)
         self.bind('<Leave>', self.on_leave)
 
     def on_enter(self, e):
-        self.configure(bg=RETRO_COLORS['button_hover'])
+        self.configure(bg=PARCHMENT_COLORS['button_hover'])
 
     def on_leave(self, e):
-        self.configure(bg=RETRO_COLORS['button_bg'])
+        self.configure(bg=PARCHMENT_COLORS['button_bg'])
 
 
-class RetroFrame(tk.Frame):
-    """Custom retro-styled frame with border"""
+class ParchmentFrame(tk.Frame):
+    """Custom parchment-styled frame with worn texture appearance"""
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
         self.configure(
-            bg=RETRO_COLORS['bg_secondary'],
+            bg=PARCHMENT_COLORS['bg_secondary'],
             relief='ridge',
-            bd=4,
-            highlightbackground=RETRO_COLORS['border_green'],
-            highlightthickness=2
-        )
-
-
-class RetroLabel(tk.Label):
-    """Custom retro-styled label"""
-
-    def __init__(self, master, **kwargs):
-        super().__init__(master, **kwargs)
-        self.configure(
-            bg=RETRO_COLORS['bg_secondary'],
-            fg=RETRO_COLORS['accent_green'],
-            font=('Courier', 11, 'bold'),
-            relief='sunken',
             bd=2,
-            highlightbackground=RETRO_COLORS['border_green'],
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
             highlightthickness=1
         )
 
 
-class RetroText(tk.Text):
-    """Custom retro-styled text widget"""
+class ParchmentLabel(tk.Label):
+    """Custom parchment-styled label with serif font"""
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
         self.configure(
-            bg=RETRO_COLORS['text_dark'],
-            fg=RETRO_COLORS['accent_green'],
-            font=('Courier', 10),
-            relief='sunken',
-            bd=3,
-            selectbackground=RETRO_COLORS['selection_green'],
-            selectforeground=RETRO_COLORS['text_dark'],
-            insertbackground=RETRO_COLORS['accent_green'],
-            highlightbackground=RETRO_COLORS['border_green'],
-            highlightthickness=2
+            bg=PARCHMENT_COLORS['bg_secondary'],
+            fg=PARCHMENT_COLORS['text_charcoal'],
+            font=('Georgia', 11, 'bold'),
+            relief='flat',
+            bd=1,
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
+            highlightthickness=1
         )
 
 
-class RetroListbox(tk.Listbox):
-    """Custom retro-styled listbox"""
+class ParchmentText(tk.Text):
+    """Custom parchment-styled text widget"""
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
         self.configure(
-            bg=RETRO_COLORS['text_dark'],
-            fg=RETRO_COLORS['accent_green'],
-            font=('Courier', 10),
+            bg=PARCHMENT_COLORS['bg_primary'],
+            fg=PARCHMENT_COLORS['text_charcoal'],
+            font=('Georgia', 10),
             relief='sunken',
-            bd=3,
-            selectbackground=RETRO_COLORS['selection_green'],
-            selectforeground=RETRO_COLORS['text_dark'],
-            highlightbackground=RETRO_COLORS['border_green'],
-            highlightthickness=2
+            bd=2,
+            selectbackground=PARCHMENT_COLORS['selection_gold'],
+            selectforeground=PARCHMENT_COLORS['text_charcoal'],
+            insertbackground=PARCHMENT_COLORS['accent_rust'],
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
+            highlightthickness=1
         )
 
 
-class RetroCanvas(tk.Canvas):
-    """Custom retro-styled canvas"""
+class ParchmentListbox(tk.Listbox):
+    """Custom parchment-styled listbox"""
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
         self.configure(
-            bg=RETRO_COLORS['text_dark'],
+            bg=PARCHMENT_COLORS['bg_primary'],
+            fg=PARCHMENT_COLORS['text_charcoal'],
+            font=('Georgia', 10),
             relief='sunken',
-            bd=3,
-            highlightbackground=RETRO_COLORS['border_green'],
-            highlightthickness=2
+            bd=2,
+            selectbackground=PARCHMENT_COLORS['selection_gold'],
+            selectforeground=PARCHMENT_COLORS['text_charcoal'],
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
+            highlightthickness=1
+        )
+
+
+class ParchmentCanvas(tk.Canvas):
+    """Custom parchment-styled canvas"""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.configure(
+            bg=PARCHMENT_COLORS['bg_primary'],
+            relief='sunken',
+            bd=2,
+            highlightbackground=PARCHMENT_COLORS['border_charcoal'],
+            highlightthickness=1
         )
 
 
 class LibraryWindow(tk.Toplevel):
     def __init__(self, master):
         super().__init__(master)
-        self.title("🐚🪲 artiFACTS 🦂🦴")
-        self.configure(bg=RETRO_COLORS['bg_primary'])
+        self.title("📚 Artifact Catalog")
+        self.configure(bg=PARCHMENT_COLORS['bg_primary'])
 
-        self.geometry("1200x700")
+        # Set to fullscreen
+        self.state('zoomed')  # For Windows
+        self.attributes('-zoomed', True)  # For Linux
+        self.attributes('-fullscreen', True)  # Fallback
 
-        # Add retro title
-        title_label = RetroLabel(self, text="🐚🪲 artiFACTS 🦂🦴",
-                                 font=('Courier', 22, 'bold'))
-        title_label.pack(pady=10)
+        # Add academic title
+        title_label = ParchmentLabel(self, text="📚 Artifact Catalog & Research Database",
+                                     font=('Georgia', 24, 'bold'))
+        title_label.pack(pady=20)
 
-        main_frame = RetroFrame(self)
-        main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        main_frame = ParchmentFrame(self)
+        main_frame.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
 
-        self.left_frame = RetroFrame(main_frame)
-        self.left_frame.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
+        self.left_frame = ParchmentFrame(main_frame)
+        self.left_frame.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=10)
 
-        # Add retro label for listbox
-        list_label = RetroLabel(self.left_frame, text="📖 ITEM CATALOG")
-        list_label.pack(pady=(5, 0))
+        # Add academic label for listbox
+        list_label = ParchmentLabel(self.left_frame, text="📖 Collection Index",
+                                    font=('Georgia', 14, 'bold'))
+        list_label.pack(pady=(10, 5))
 
-        self.listbox = RetroListbox(self.left_frame, width=40)
-        self.listbox.pack(fill=tk.Y, expand=True, padx=5, pady=5)
+        self.listbox = ParchmentListbox(self.left_frame, width=45)
+        self.listbox.pack(fill=tk.Y, expand=True, padx=10, pady=10)
         self.listbox.bind("<<ListboxSelect>>", self.display_item_info)
 
-        self.right_frame = RetroFrame(main_frame)
+        self.right_frame = ParchmentFrame(main_frame)
         self.right_frame.pack(side=tk.RIGHT, fill=tk.BOTH,
-                              expand=True, padx=5, pady=5)
+                              expand=True, padx=10, pady=10)
 
-        # Image section with retro styling
-        image_label = RetroLabel(self.right_frame, text="🖼️ ITEM PHOTOS")
-        image_label.pack(pady=(5, 0))
+        # Image section with academic styling
+        image_label = ParchmentLabel(self.right_frame, text="🖼️ Artifact Documentation",
+                                     font=('Georgia', 14, 'bold'))
+        image_label.pack(pady=(10, 5))
 
-        self.image_frame = RetroFrame(self.right_frame)
-        self.image_frame.pack(fill='x', pady=(5, 10), padx=5)
+        self.image_frame = ParchmentFrame(self.right_frame)
+        self.image_frame.pack(fill='x', pady=(5, 15), padx=10)
 
-        self.image_canvas = RetroCanvas(self.image_frame, height=320)
+        self.image_canvas = ParchmentCanvas(self.image_frame, height=350)
         self.image_canvas.pack(side='top', fill='x',
-                               expand=True, padx=5, pady=5)
+                               expand=True, padx=10, pady=10)
 
         self.scroll_x = tk.Scrollbar(
             self.image_frame, orient='horizontal', command=self.image_canvas.xview)
@@ -246,12 +253,13 @@ class LibraryWindow(tk.Toplevel):
         self.image_canvas.bind("<ButtonPress-1>", self.start_scroll)
         self.image_canvas.bind("<B1-Motion>", self.do_scroll)
 
-        # Info section with retro styling
-        info_label = RetroLabel(self.right_frame, text="📋 ITEM DETAILS")
-        info_label.pack(pady=(10, 0))
+        # Info section with academic styling
+        info_label = ParchmentLabel(self.right_frame, text="📋 Artifact Details & Analysis",
+                                     font=('Georgia', 14, 'bold'))
+        info_label.pack(pady=(15, 5))
 
-        self.info_text = RetroText(self.right_frame, wrap='word')
-        self.info_text.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.info_text = ParchmentText(self.right_frame, wrap='word')
+        self.info_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         self.photo_refs = []
 
@@ -295,9 +303,9 @@ class LibraryWindow(tk.Toplevel):
                     continue  # skip photo path listing
                 if val:
                     label = col_names[i].replace("_", " ").capitalize()
-                    self.info_text.insert(tk.END, f"🎯 {label}: {val}\n\n")
+                    self.info_text.insert(tk.END, f"🔍 {label}: {val}\n\n")
         else:
-            self.info_text.insert(tk.END, "❌ Item not found.")
+            self.info_text.insert(tk.END, "❌ Artifact not found in database.")
         self.info_text.config(state='disabled')
 
         photo_folder = os.path.join(PHOTO_DIR, item_name.replace(" ", "_"))
@@ -313,11 +321,11 @@ class LibraryWindow(tk.Toplevel):
         for idx, path in enumerate(image_paths):
             try:
                 img = Image.open(path)
-                img.thumbnail((300, 300), Image.Resampling.LANCZOS)
+                img.thumbnail((320, 320), Image.Resampling.LANCZOS)
                 img_tk = ImageTk.PhotoImage(img)
-                x = 310 * idx + 10
+                x = 330 * idx + 15
                 self.image_canvas.create_image(
-                    x, 10, anchor='nw', image=img_tk)
+                    x, 15, anchor='nw', image=img_tk)
                 self.photo_refs.append(img_tk)
             except Exception as e:
                 print(f"Failed to load image: {path}\n{e}")
@@ -328,14 +336,16 @@ class LibraryWindow(tk.Toplevel):
 class ClassifierApp:
     def __init__(self, master):
         self.master = master
-        self.master.title("🐚🪲 artiFACTS 🦂🦴")
-        self.master.configure(bg=RETRO_COLORS['bg_primary'])
+        self.master.title("📚 Artifact Research & Classification System")
+        self.master.configure(bg=PARCHMENT_COLORS['bg_primary'])
 
-        # Set window icon and styling
-        self.master.geometry("900x700")
+        # Set window to fullscreen
+        self.master.state('zoomed')  # For Windows
+        self.master.attributes('-zoomed', True)  # For Linux
+        self.master.attributes('-fullscreen', True)  # Fallback
 
         # Create a canvas for the main window with scrollbars
-        self.main_canvas = RetroCanvas(self.master)
+        self.main_canvas = ParchmentCanvas(self.master)
         self.main_canvas.pack(side='left', fill='both', expand=True)
 
         # Add scrollbars to main window
@@ -353,23 +363,23 @@ class ClassifierApp:
         )
 
         # Main content frame inside canvas
-        main_frame = RetroFrame(self.main_canvas)
+        main_frame = ParchmentFrame(self.main_canvas)
         # Create window with proper width (accounting for scrollbar)
-        initial_width = max(800, self.master.winfo_width() - 50)
+        initial_width = max(1000, self.master.winfo_width() - 50)
         self.main_canvas.create_window(
             (0, 0), window=main_frame, anchor='nw', width=initial_width)
 
-        # Main title with retro styling (now inside the canvas)
-        title_frame = RetroFrame(main_frame)
-        title_frame.pack(fill=tk.X, padx=20, pady=20)
+        # Main title with academic styling
+        title_frame = ParchmentFrame(main_frame)
+        title_frame.pack(fill=tk.X, padx=30, pady=30)
 
-        title_label = RetroLabel(title_frame, text="🐚🪲 artiFACTS 🦂🦴",
-                                 font=('Courier', 22, 'bold'))
-        title_label.pack(pady=15)
+        title_label = ParchmentLabel(title_frame, text="📚 Artifact Research & Classification System",
+                                     font=('Georgia', 28, 'bold'))
+        title_label.pack(pady=20)
 
-        subtitle_label = RetroLabel(title_frame, text="Your curiosities library!",
-                                    font=('Courier', 12))
-        subtitle_label.pack(pady=(0, 15))
+        subtitle_label = ParchmentLabel(title_frame, text="Academic Explorer's Field Journal",
+                                        font=('Georgia', 16, 'italic'))
+        subtitle_label.pack(pady=(0, 20))
 
         # Bind mouse wheel scrolling
         self.main_canvas.bind('<MouseWheel>', self.on_mousewheel)
@@ -377,74 +387,78 @@ class ClassifierApp:
         self.main_canvas.bind('<Button-5>', self.on_mousewheel)
 
         # Image display section
-        image_frame = RetroFrame(main_frame)
-        image_frame.pack(fill=tk.X, padx=10, pady=10)
+        image_frame = ParchmentFrame(main_frame)
+        image_frame.pack(fill=tk.X, padx=20, pady=20)
 
-        image_label = RetroLabel(image_frame, text="🖼️ SELECTED IMAGE")
-        image_label.pack(pady=(5, 0))
+        image_label = ParchmentLabel(image_frame, text="🖼️ Selected Artifact Image",
+                                     font=('Georgia', 14, 'bold'))
+        image_label.pack(pady=(10, 5))
 
-        self.image_label = RetroLabel(image_frame, text="No image selected",
-                                      font=('Courier', 12))
-        self.image_label.pack(pady=10)
+        self.image_label = ParchmentLabel(image_frame, text="No artifact image selected",
+                                          font=('Georgia', 12))
+        self.image_label.pack(pady=15)
 
-        # Button section with retro styling
-        btn_frame = RetroFrame(main_frame)
-        btn_frame.pack(fill=tk.X, padx=10, pady=10)
+        # Button section with academic styling
+        btn_frame = ParchmentFrame(main_frame)
+        btn_frame.pack(fill=tk.X, padx=20, pady=20)
 
-        btn_label = RetroLabel(btn_frame, text="🎛️ CONTROL PANEL")
-        btn_label.pack(pady=(5, 10))
+        btn_label = ParchmentLabel(btn_frame, text="🎛️ Research Controls",
+                                   font=('Georgia', 14, 'bold'))
+        btn_label.pack(pady=(10, 15))
 
-        button_container = tk.Frame(btn_frame, bg=RETRO_COLORS['bg_secondary'])
-        button_container.pack(pady=(0, 10))
+        button_container = tk.Frame(btn_frame, bg=PARCHMENT_COLORS['bg_secondary'])
+        button_container.pack(pady=(0, 15))
 
-        self.select_button = RetroButton(
-            button_container, text="📁 Select Image", command=self.select_image)
-        self.select_button.grid(row=0, column=0, padx=10, pady=10)
+        self.select_button = ParchmentButton(
+            button_container, text="📁 Select Artifact Image", command=self.select_image)
+        self.select_button.grid(row=0, column=0, padx=15, pady=15)
 
-        self.capture_button = RetroButton(
-            button_container, text="📷 Capture Image", command=self.capture_image)
-        self.capture_button.grid(row=0, column=1, padx=10, pady=10)
+        self.capture_button = ParchmentButton(
+            button_container, text="📷 Capture Artifact Image", command=self.capture_image)
+        self.capture_button.grid(row=0, column=1, padx=15, pady=15)
 
-        self.library_button = RetroButton(
-            button_container, text="📚 View Library", command=self.view_library)
-        self.library_button.grid(row=0, column=2, padx=10, pady=10)
+        self.library_button = ParchmentButton(
+            button_container, text="📚 View Artifact Catalog", command=self.view_library)
+        self.library_button.grid(row=0, column=2, padx=15, pady=15)
 
         # Options section
-        options_frame = RetroFrame(main_frame)
-        options_frame.pack(fill=tk.X, padx=10, pady=10)
+        options_frame = ParchmentFrame(main_frame)
+        options_frame.pack(fill=tk.X, padx=20, pady=20)
 
-        options_label = RetroLabel(options_frame, text="⚙️ OPTIONS")
-        options_label.pack(pady=(5, 0))
+        options_label = ParchmentLabel(options_frame, text="⚙️ Analysis Options",
+                                       font=('Georgia', 14, 'bold'))
+        options_label.pack(pady=(10, 5))
 
         self.top3_var = tk.BooleanVar()
-        # Create a custom retro checkbox with better visual indication
+        # Create a custom parchment checkbox
         checkbox_frame = tk.Frame(
-            options_frame, bg=RETRO_COLORS['bg_secondary'])
-        checkbox_frame.pack(pady=10)
+            options_frame, bg=PARCHMENT_COLORS['bg_secondary'])
+        checkbox_frame.pack(pady=15)
 
         self.top3_check = tk.Checkbutton(
-            checkbox_frame, text="Show Top 3 Predictions", variable=self.top3_var,
-            bg=RETRO_COLORS['bg_secondary'], fg=RETRO_COLORS['accent_green'],
-            font=('Courier', 10, 'bold'), selectcolor=RETRO_COLORS['selection_green'],
-            activebackground=RETRO_COLORS['bg_secondary'],
-            activeforeground=RETRO_COLORS['accent_green'],
-            indicatoron=True,  # Show the checkbox indicator
-            relief='raised',    # Raised appearance
-            bd=2               # Border width for better visibility
+            checkbox_frame, text="Show Top 3 Classifications", variable=self.top3_var,
+            bg=PARCHMENT_COLORS['bg_secondary'], fg=PARCHMENT_COLORS['text_charcoal'],
+            font=('Georgia', 11, 'bold'), selectcolor=PARCHMENT_COLORS['selection_gold'],
+            activebackground=PARCHMENT_COLORS['bg_secondary'],
+            activeforeground=PARCHMENT_COLORS['text_charcoal'],
+            indicatoron=True,
+            relief='raised',
+            bd=2
         )
-        self.top3_check.pack(pady=10)
+        self.top3_check.pack(pady=15)
 
         # Results section
-        results_frame = RetroFrame(main_frame)
-        results_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        results_frame = ParchmentFrame(main_frame)
+        results_frame.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
 
-        results_label = RetroLabel(
-            results_frame, text="🔍 CLASSIFICATION RESULTS")
-        results_label.pack(pady=(5, 0))
+        results_label = ParchmentLabel(
+            results_frame, text="🔍 Classification Results & Analysis",
+             font=('Georgia', 14, 'bold'))
+        results_label.pack(pady=(10, 5))
 
-        self.result_text = RetroText(
-            results_frame, height=12, width=80, state='disabled', wrap='word')
-        self.result_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        self.result_text = ParchmentText(
+            results_frame, height=15, width=90, state='disabled', wrap='word')
+        self.result_text.pack(fill=tk.BOTH, expand=True, padx=15, pady=15)
 
         # Bind main frame resize to update scroll region
         main_frame.bind('<Configure>',
@@ -502,8 +516,7 @@ class ClassifierApp:
 
     def process_image(self, file_path):
         try:
-            img = Image.open(file_path).resize(
-                (320, 320))  # Reduced by 20% from 400x400
+            img = Image.open(file_path).resize((350, 350))
             tk_img = ImageTk.PhotoImage(img)
             self.image_label.config(image=tk_img, text="")
             self.image_label.image = tk_img
@@ -517,7 +530,7 @@ class ClassifierApp:
     def process_frame(self, frame):
         try:
             img = Image.fromarray(cv2.cvtColor(
-                frame, cv2.COLOR_BGR2RGB)).resize((320, 320))  # Reduced by 20% from 400x400
+                frame, cv2.COLOR_BGR2RGB)).resize((350, 350))
             tk_img = ImageTk.PhotoImage(img)
             self.image_label.config(image=tk_img, text="")
             self.image_label.image = tk_img
@@ -534,17 +547,17 @@ class ClassifierApp:
 
         for i, (label, confidence, description, fact) in enumerate(results):
             if i == 0:
-                self.result_text.insert(tk.END, f"🏆 TOP PREDICTION: {label}\n")
+                self.result_text.insert(tk.END, f"🏆 PRIMARY CLASSIFICATION: {label}\n")
             else:
                 self.result_text.insert(
-                    tk.END, f"🥈 PREDICTION {i+1}: {label}\n")
+                    tk.END, f"🥈 ALTERNATIVE CLASSIFICATION {i+1}: {label}\n")
 
             self.result_text.insert(
-                tk.END, f"   🎯 Confidence: {confidence:.2%}\n")
+                tk.END, f"   🎯 Confidence Level: {confidence:.2%}\n")
             self.result_text.insert(
-                tk.END, f"   📜 Description: {description}\n")
+                tk.END, f"   📜 Artifact Description: {description}\n")
             if fact:
-                self.result_text.insert(tk.END, f"   💡 Fun Fact: {fact}\n")
+                self.result_text.insert(tk.END, f"   💡 Historical Note: {fact}\n")
             self.result_text.insert(tk.END, "\n")
 
         self.result_text.config(state='disabled')


### PR DESCRIPTION
Set GUI to open in fullscreen by default and apply a parchment-toned academic explorer styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-84371033-18c0-40f7-9ae1-35262b308738">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84371033-18c0-40f7-9ae1-35262b308738">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

